### PR TITLE
List all navigation links on every page

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,8 +9,11 @@
     <header>
         <h1>Code Coop</h1>
         <nav>
-            <a href="index.html" title="Home page">Home</a>
-            <a href="contact.html" title="Contact page with contact details">Contact Us</a>
+            <ul>
+                <li><a href="index.html" title="Home page">Home</a></li>
+                <li><a href="about.html" title="About page and what we do">About</a></li>
+                <li><a href="contact.html" title="Contact page with contact details">Contact Us</a></li>
+            </ul>
         </nav>
     </header>
       <main>

--- a/contact.html
+++ b/contact.html
@@ -9,8 +9,11 @@
     <header>
         <h1>Code Coop</h1>
         <nav>
-            <a href="index.html" title="Home page">Home</a>
-            <a href="about.html" title="About page and what we do">About</a>
+            <ul>
+                <li><a href="index.html" title="Home page">Home</a></li>
+                <li><a href="about.html" title="About page and what we do">About</a></li>
+                <li><a href="contact.html" title="Contact page with contact details">Contact Us</a></li>
+            </ul>
         </nav>
     </header>
       <main>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,11 @@
     <header>
         <h1>Code Coop</h1>
         <nav>
-            <a href="about.html" title="About page and what we do">About</a>
-            <a href="contact.html" title="Contact page with contact details">Contact Us</a>
+            <ul>
+                <li><a href="index.html" title="Home page">Home</a></li>
+                <li><a href="about.html" title="About page and what we do">About</a></li>
+                <li><a href="contact.html" title="Contact page with contact details">Contact Us</a></li>
+            </ul>
         </nav>
     </header>
       <main>


### PR DESCRIPTION
## What's changed?

All navigation links are now listed regardless of which page you are on. I think this is more in line with what other websites do. Previously, we only listed links to all other pages.

It looks like navigation links to each page make up a 'list'. What do you think about turning it into a `<ul>` to reflect that in the markup?

Page | Before | After
--- | --- | ---
Home | ![image](https://user-images.githubusercontent.com/13058213/50272412-a3d30380-042f-11e9-894d-2e02bde033d2.png) | ![image](https://user-images.githubusercontent.com/13058213/50272340-62425880-042f-11e9-9bc8-9f1001a8160e.png)
About | ![image](https://user-images.githubusercontent.com/13058213/50272420-a897b780-042f-11e9-803e-3c123327527e.png) | ![image](https://user-images.githubusercontent.com/13058213/50272335-60789500-042f-11e9-8e37-00e50f0565ee.png)
Contact | ![image](https://user-images.githubusercontent.com/13058213/50272447-bbaa8780-042f-11e9-95cc-77cf9d4e3027.png) | ![image](https://user-images.githubusercontent.com/13058213/50272343-640c1c00-042f-11e9-83ed-5b45ef1178cd.png)